### PR TITLE
devtools_options.yaml を git に登録しないように

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ app.*.map.json
 
 # FVM Version Cache
 .fvm/
+
+devtools_options.yaml


### PR DESCRIPTION
## やりたいこと
  - devtools を使うと `devtools_options.yaml`  が生成されるので、それは ignore するように