### PR TITLE
chore: pin GitHub Actions to commit hashes and bump to latest versions

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
@@ -27,17 +27,17 @@ jobs:
         run: |
           mkdir -p $HOME/.ssh/
 
-      - uses: kuhnroyal/flutter-fvm-config-action@v2
+      - uses: kuhnroyal/flutter-fvm-config-action@c378498f1d1962d33039c3989411093ef8a17b2c # v3.3
         id: fvm-config-action
 
-      - uses: subosito/flutter-action@v2.18.0
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
           cache: true
 
       - name: restore pubspec dependencies cache
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: pubspec_cache_id
         with:
           path: |
@@ -58,21 +58,21 @@ jobs:
     needs: setup
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
-      - uses: kuhnroyal/flutter-fvm-config-action@v3
+      - uses: kuhnroyal/flutter-fvm-config-action@c378498f1d1962d33039c3989411093ef8a17b2c # v3.3
         id: fvm-config-action
 
-      - uses: subosito/flutter-action@v2.18.0
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
           cache: true
 
       - name: restore pubspec dependencies cache
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: pubspec_cache_id
         with:
           path: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,18 +15,18 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
-      - uses: dart-lang/setup-dart@v1
+      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
         with:
           sdk: 3.7.0
 
-      - uses: kuhnroyal/flutter-fvm-config-action@v3
+      - uses: kuhnroyal/flutter-fvm-config-action@c378498f1d1962d33039c3989411093ef8a17b2c # v3.3
         id: fvm-config-action
 
-      - uses: subosito/flutter-action@v2.18.0
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}


### PR DESCRIPTION
# Description
Pins all third-party GitHub Actions to specific commit hashes for supply chain security, and bumps them to their latest versions.

# What was done
- Replaced tag-based version references with commit hash pinning for all actions
- Updated all actions to their latest releases:
  - `actions/checkout`: `v4` → `de0fac2e` (v6.0.2)
  - `actions/cache`: `v4` → `27d5ce7f` (v5.0.5)
  - `dart-lang/setup-dart`: `v1` → `65eb853c` (v1.7.2)
  - `kuhnroyal/flutter-fvm-config-action`: `v2`/`v3` → `c378498f` (v3.3)
  - `subosito/flutter-action`: `v2.18.0` → `1a449444` (v2.23.0)
- Added inline version comments (e.g. `# v6.0.2`) for readability

# What was NOT done
- Pinning `runs-on` runner versions (out of scope)

# Operation Confirmation

## Prerequisites & Steps
Verify CI passes on this branch after merge.

# Notes & Related URLs
Commit hash pinning prevents supply chain attacks where a tag is silently moved to a different (potentially malicious) commit.