### PR TITLE
feat: add workflow to auto-create release PR

### DIFF
--- a/.github/templates/git-pr-release.erb
+++ b/.github/templates/git-pr-release.erb
@@ -1,0 +1,9 @@
+【Production Release】<%= Time.now.strftime('%Y-%m-%d %H:%M') %>
+
+## Description
+Distribute DevTool Extension :rocket:
+
+## Target PR
+<% pull_requests.each do |pr| -%>
+- #<%= pr.number %> by <%= pr.mention %>
+<% end -%>

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,0 +1,33 @@
+name: Create Production Release PR
+
+on:
+  push:
+    branches: [develop]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  release-pull-request:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64 # v1.299.0
+        with:
+          ruby-version: 3.3
+          bundler-cache: true
+
+      - run: gem install --no-document git-pr-release
+
+      - run: git-pr-release
+        env:
+          GIT_PR_RELEASE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_PR_RELEASE_BRANCH_PRODUCTION: release
+          GIT_PR_RELEASE_BRANCH_STAGING: develop
+          GIT_PR_RELEASE_LABELS: release
+          GIT_PR_RELEASE_TEMPLATE: .github/templates/git-pr-release.erb
+          TZ: Asia/Tokyo


### PR DESCRIPTION
# Description
Adds a GitHub Actions workflow that automatically creates a production release PR
when changes are pushed to the `develop` branch, using `git-pr-release`.

# What was done
- Added `.github/workflows/create-release-pr.yml`: workflow that runs on push to `develop` and creates a PR from `develop` → `release` via `git-pr-release`
- Added `.github/templates/git-pr-release.erb`: PR template listing merged PRs as targets

# What was NOT done
- Creating the `release` branch itself (assumed to exist)
- Setting up the `GITHUB_TOKEN` secret (provided automatically by GitHub Actions)

# Operation Confirmation

## Prerequisites & Steps
1. Ensure a `release` branch exists on the remote
2. Push a commit to `develop` to trigger the workflow
3. Verify a PR is created from `develop` → `release` with the expected template

# Notes & Related URLs
N/A