### PR TITLE
feat: introduce cider for CHANGELOG management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,32 +1,60 @@
-## 0.0.5
+## [0.0.5] - 2025-03-11
+
+### Changed
+
+  - Include build when publishing.
+
+### Fixed
 
   - Fix dart sdk version in CI.
   - Fix repo name in issue trakcer.
-  - Include build when publishing.
 
-## 0.0.4
+## [0.0.4] - 2025-03-10
+
+### Changed
 
   - Improve score on pub.dev
 
-## 0.0.3
+## [0.0.3] - 2025-02-27
+
+### Added
+
+  - Add example/example.md to create Example tab on pub.dev
+
+### Changed
 
   - Bump Flutter SDK to 3.29.0
   - Update dependencies
   - Follow dart file conventions to improve score on pub.dev
-  - Add example/example.md to create Example tab on pub.dev
 
-## 0.0.2
+## [0.0.2] - 2025-01-18
+
+### Fixed
 
   - Fix README.md
 
-## 0.0.1
+## [0.0.1] - 2025-01-17
+
+### Added
 
   - First Official Release!! 🎉🎉🎉
 
-## 0.0.1-dev.2
+## [0.0.1-dev.2] - 2025-01-17
+
+### Changed
 
   - Update README.md
 
-## 0.0.1-dev.1
+## [0.0.1-dev.1] - 2025-01-16
+
+### Added
 
   - Initial release. This package is under construction.
+
+[0.0.5]: https://github.com/offich/panache/compare/v0.0.4...v0.0.5
+[0.0.4]: https://github.com/offich/panache/compare/v0.0.3...v0.0.4
+[0.0.3]: https://github.com/offich/panache/compare/v0.0.2...v0.0.3
+[0.0.2]: https://github.com/offich/panache/compare/v0.0.1...v0.0.2
+[0.0.1]: https://github.com/offich/panache/compare/v0.0.1-dev.2...v0.0.1
+[0.0.1-dev.2]: https://github.com/offich/panache/compare/v0.0.1-dev.1...v0.0.1-dev.2
+[0.0.1-dev.1]: https://github.com/offich/panache/releases/tag/v0.0.1-dev.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Changed
+
+  - flutter 3.38.10
+
 ## [0.0.5] - 2025-03-11
 
 ### Changed

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -41,6 +41,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  change:
+    dependency: transitive
+    description:
+      name: change
+      sha256: "3bda1ce98526b21927cdea05688563c7065fd7e66d1abbe176c354fef3b2057b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.5"
   characters:
     dependency: transitive
     description:
@@ -57,6 +65,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
+  cider:
+    dependency: "direct dev"
+    description:
+      name: cider
+      sha256: "27b9cd9526c70d6cd47299cd644cddaac8102e5f9783ef4bb440840743271883"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.10"
   cli_util:
     dependency: transitive
     description:
@@ -368,6 +384,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.3.0"
+  marker:
+    dependency: transitive
+    description:
+      name: marker
+      sha256: "3dadd01f3b0ffae148ffb3b1bc04290a98e54a465cddbab59727bd2a9fe57750"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.0"
   matcher:
     dependency: transitive
     description:
@@ -504,6 +528,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
+  rfc_6901:
+    dependency: transitive
+    description:
+      name: rfc_6901
+      sha256: "6a43b1858dca2febaf93e15639aa6b0c49ccdfd7647775f15a499f872b018154"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   safe_url_check:
     dependency: transitive
     description:
@@ -741,6 +773,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  version_manipulation:
+    dependency: transitive
+    description:
+      name: version_manipulation
+      sha256: e90782d610bde19765d2808ec06bc8ed9e04640a4dd07d1a3d370728ce9dae7f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   vm_service:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,6 +53,7 @@ dev_dependencies:
   # rules and activating additional ones.
   flutter_lints: 6.0.0
   pana: 0.23.11
+  cider: 0.2.10
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
# Description
Introduces [cider](https://pub.dev/packages/cider) as a dev dependency to manage CHANGELOG.md in Keep a Changelog format. The CHANGELOG is reformatted to follow the new structure, and an Unreleased section is added for upcoming changes.

# What was done
- Added `cider` (0.2.10) as a dev dependency in `pubspec.yaml`
- Reformatted `CHANGELOG.md` to Keep a Changelog format:
  - Versioned headers changed to `## [x.x.x] - YYYY-MM-DD`
  - Entries categorized under `### Added`, `### Changed`, `### Fixed`
  - Comparison links added to the footer
- Added `## Unreleased` section with the upcoming Flutter 3.38.10 update

# What was NOT done
- No automation scripts for release workflows (to be handled separately)

# Operation Confirmation

## Setup & Execution
Run `dart run cider` to manage changelog entries (e.g., `dart run cider bump minor`).

# Notes / Related URLs
- https://pub.dev/packages/cider