### PR TITLE
feat: split publish workflow into create-tag and publish

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -1,0 +1,38 @@
+name: Create Release
+
+on:
+  push:
+    branches:
+      - release
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from pubspec.yaml
+        id: version
+        run: |
+          VERSION=$(grep '^version:' pubspec.yaml | awk '{print $2}')
+          VERSION_NAME=$(echo $VERSION | cut -d'+' -f1)
+          TAG_NAME="v${VERSION}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version_name=$VERSION_NAME" >> $GITHUB_OUTPUT
+          echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
+          echo "Version: $VERSION (Tag: $TAG_NAME)"
+
+      - name: Create and push tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a ${{ steps.version.outputs.tag_name }} -m "Release ${{ steps.version.outputs.version }}"
+          git push origin ${{ steps.version.outputs.tag_name }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,3 +42,33 @@ jobs:
 
       - name: Publish
         run: dart pub publish --force
+
+  release:
+    needs: [publish]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Extract release notes from CHANGELOG
+        id: release_notes
+        uses: octivi/release-notes-from-changelog@7e6de14efd823919839acf82f08041f885c8fca9 # v1.0.0
+        with:
+          tag: ${{ github.ref_name }}
+          changelog: CHANGELOG.md
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
+          body_path: ${{ steps.release_notes.outputs.release_notes }}
+          draft: false
+          prerelease: false


### PR DESCRIPTION
# Description
Splits the release flow into two separate workflows to fix pub.dev publishing
which requires a tag refType. The release flow is now:

1. Push to `release` branch → `create-tag.yml` creates and pushes a `v*` tag
2. Tag push triggers `publish.yml` → publishes to pub.dev, then creates a GitHub Release

# What was done
- Added `.github/workflows/create-tag.yml`: triggered on push to `release` branch,
  extracts version from `pubspec.yaml`, creates and pushes a git tag
- Updated `.github/workflows/publish.yml`: added a `release` job (`needs: [publish]`)
  that extracts release notes from CHANGELOG.md and creates a GitHub Release
  after pub.dev publish succeeds

# What was NOT done
- Did not change the publish logic itself (validate, build_and_copy, dart pub publish)

# Operation Confirmation

## Prerequisites & Steps
1. Merge PR into `release` branch
2. `create-tag.yml` runs automatically and pushes a `v*` tag
3. Tag push triggers `publish.yml` — pub.dev publish → GitHub Release

# Notes / Related URLs
- Reference: https://github.com/offich/sangria/pull/57